### PR TITLE
fix: use correct certificate duration format

### DIFF
--- a/deploy/infomaniak-webhook/templates/pki.yaml
+++ b/deploy/infomaniak-webhook/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "infomaniak-webhook.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "infomaniak-webhook.selfSignedIssuer" . }}
   commonName: "ca.infomaniak-webhook.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "infomaniak-webhook.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "infomaniak-webhook.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
Hi,

I'd like to suggest the following changes.
This PR fixed the duration format of the certificates.
While it does change its value, it uses the correct duration format.

This change is needed as some tools like ArgoCD detects difference between theoretical and applied values, causing infinite reconciliation attempts.

Thank you in advance