### PR TITLE
Add Flux HelmRelease docs to chart README

### DIFF
--- a/deploy/infomaniak-webhook/README.md
+++ b/deploy/infomaniak-webhook/README.md
@@ -1,0 +1,41 @@
+# Infomaniak ACME Webhook - Helm Chart
+
+## Flux Helm Release
+
+If you are using Flux to manage your configuration, a `GitRepository` can be used as a source for the `HelmRelease`.
+This also allows for customization of the chart values.
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: infomaniak-webhook
+  namespace: cert-manager
+spec:
+  interval: 5m
+  url: https://github.com/Infomaniak/cert-manager-webhook-infomaniak
+  ref:
+    branch: master
+  ignore: |
+    /*
+    !/deploy/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: infomaniak-webhook
+  namespace: cert-manager
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: deploy/infomaniak-webhook
+      sourceRef:
+        kind: GitRepository
+        name: infomaniak-webhook
+  values:
+    groupName: example.com
+    secretsNames:
+      - infomaniak-api-credentials
+```


### PR DESCRIPTION
Salut,

I figured out how to manage a Helm release of this webhook's chart using Flux. There does not seem to be an official repository where this chart is available (as far as I am aware), but it is possible by using this repo as a `GitRepository` source.

This only adds some content to the chart README but might be useful for others attempting the same.

Thank you for your work and providing this.