### PR TITLE
feat(chart): add http proxy settings

### DIFF
--- a/deploy/infomaniak-webhook/templates/deployment.yaml
+++ b/deploy/infomaniak-webhook/templates/deployment.yaml
@@ -36,6 +36,18 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+            {{- with .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.no_proxy }}
+            - name: NO_PROXY
+              value: {{ . }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/infomaniak-webhook/values.yaml
+++ b/deploy/infomaniak-webhook/values.yaml
@@ -12,6 +12,22 @@ certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager
 
+
+# Use these variables to configure the HTTP_PROXY environment variables.
+
+# Configures the HTTP_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# http_proxy: "http://proxy:8080"
+
+# Configures the HTTPS_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# https_proxy: "https://proxy:8080"
+
+# Configures the NO_PROXY environment variable where a HTTP proxy is required,
+# but certain domains should be excluded.
+# +docs:property
+# no_proxy: 127.0.0.1,localhost
+
 # used to add a namespace declaration to the static manifest,
 # prefer `--create-namespaces` with `helm install` >= 3.2
 # see https://github.com/helm/helm/issues/6794


### PR DESCRIPTION
As a cluster operator, i have to ensure that cert-manager and its related components can perform queries to internet through an http proxy.

Adds capability to use the webhook with an http proxy.
