### PR TITLE
Fix Helm RBAC Role to support multiple secretNames

### DIFF
--- a/deploy/infomaniak-webhook/templates/rbac.yaml
+++ b/deploy/infomaniak-webhook/templates/rbac.yaml
@@ -105,7 +105,10 @@ rules:
   - apiGroups: [""]
     resources:
       - 'secrets'
-    resourceNames: {{ .Values.secretsNames }}
+    resourceNames:
+{{- range .Values.secretsNames }}
+      - "{{ . }}"
+{{- end }}
     verbs:
       - 'get'
       - 'watch'


### PR DESCRIPTION
The current Helm template for the Role resource does not correctly handle multiple secrets specified in `.Values.secretsNames`. While `.Values.secretsNames` can contain a list, only the first element is currently used.

As a result, only a single secret is added to resourceNames, which can lead to unexpected behavior when multiple secrets are provided.

### Example of current behavior:

```yaml
rules:
  - apiGroups:
      - ''
    resourceNames:
      - infomaniak-api-credentials my-infomaniak-api-credentials-v2
```

### Expected behavior:

```yaml
rules:
  - apiGroups:
      - ''
    resourceNames:
      - infomaniak-api-credentials 
      - my-infomaniak-api-credentials-v2
```

This fix updates the **rbac.yaml** template to iterate over `.Values.secretsNames`, ensuring all specified secrets are included in resourceNames.