### PR TITLE
fix(api): correct product endpoint from /1/product to /1/products

### DIFF
--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -180,7 +180,7 @@ func (ik *InfomaniakAPI) GetDomainByName(name string) (*InfomaniakDNSDomain, err
 		params.Add("service_name", "domain")
 		params.Add("customer_name", name)
 
-		resp, err := ik.get("/1/product", params)
+		resp, err := ik.get("/1/products", params)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Context

The Infomaniak API endpoint `/1/product` is deprecated. The correct endpoint is `/1/products` (plural). Using the deprecated route caused errors when looking up DNS domains.

## Solution

Updated the URL in `infomaniak_api.go` from `/1/product` to `/1/products` to use the current, non-deprecated API route.