### PR TITLE
feat: Migrate DNS records to Infomaniak API v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ test: _test/kubebuilder-$(KUBEBUILDER_VERSION)-$(OS)-$(ARCH)/etcd _test/kubebuil
 	TEST_ASSET_KUBECTL=_test/kubebuilder-$(KUBEBUILDER_VERSION)-$(OS)-$(ARCH)/kubectl \
 	$(GO) test -v .
 
+.PHONY: unit-test
+unit-test:
+	TEST_ASSET_ETCD=/dev/null \
+	TEST_ASSET_KUBE_APISERVER=/dev/null \
+	TEST_ASSET_KUBECTL=/dev/null \
+	$(GO) test -v -run 'TestGetZoneByName|TestRequestErrorEnvelope|TestZoneExists|TestGetRecordID|TestEnsureDNSRecord|TestRemoveDNSRecord|TestUpdateDNSRecord' .
+
 _test/kubebuilder-$(KUBEBUILDER_VERSION)-$(OS)-$(ARCH).tar.gz: | _test
 	curl -fsSL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(OS)_$(ARCH).tar.gz -o $@
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A cert-manager webhook which works with domains handled by [Infomaniak](https://
     $ kubectl apply -f https://github.com/infomaniak/cert-manager-webhook-infomaniak/releases/download/v0.2.0/rendered-manifest.yaml
     ```
 
-1. Create a Secret with your Infomaniak API token. You can generate a new one by [clicking here](https://manager.infomaniak.com/v3/infomaniak-api). You need to have at least the `Domain` scope.
+1. Create a Secret with your Infomaniak API token. You can generate a new one by [clicking here](https://manager.infomaniak.com/v3/infomaniak-api). You need to have at least the `dns:read` and `dns:write` scopes.
     ```
     $ cat <<EOF | kubectl apply -f -
     ---

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -125,6 +125,7 @@ func (ik *InfomaniakAPI) request(method, path string, body io.Reader) (*Infomani
 	if err != nil {
 		return nil, err
 	}
+	defer rawResp.Body.Close()
 
 	var resp InfomaniakAPIResponse
 	if err := json.NewDecoder(rawResp.Body).Decode(&resp); err != nil {

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -8,9 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
-
-	"golang.org/x/net/idna"
 
 	"k8s.io/klog/v2"
 )
@@ -169,108 +168,22 @@ func (ik *InfomaniakAPI) delete(path string) (*InfomaniakAPIResponse, error) {
 	return ik.request("DELETE", path, nil)
 }
 
-// InfomaniakDNSDomain defines the format of a Domain object
-type InfomaniakDNSDomain struct {
-	ID                  uint64           `json:"id,omitempty"`
-	AccountID           uint64           `json:"account_id,omitempty"`
-	ServiceID           uint64           `json:"service_id,omitempty"`
-	ServiceName         string           `json:"service_name,omitempty"`
-	CustomerName        string           `json:"customer_name,omitempty"`
-	InternalName        string           `json:"internal_name,omitempty,omitempty"`
-	CreatedAt           uint64           `json:"created_at,omitempty"`
-	ExpiredAt           uint64           `json:"expired_at,omitempty"`
-	Version             uint64           `json:"version,omitempty"`
-	Maintenance         bool             `json:"maintenance,omitempty"`
-	Locked              bool             `json:"locked,omitempty"`
-	OperationInProgress bool             `json:"operation_in_progress,omitempty"`
-	Tags                *json.RawMessage `json:"tags,omitempty"`
-	UniqueID            uint64           `json:"unique_id,omitempty"`
-	Description         string           `json:"description,omitempty"`
-	Isfree              bool             `json:"is_free,omitempty"`
-	Rights              *json.RawMessage `json:"rights,omitempty"`
-	Special             bool             `json:"special,omitempty"`
-}
-
-func (d *InfomaniakDNSDomain) ASCIIName() (string, error) {
-	domainASCII, err := idna.ToASCII(d.CustomerName)
-	if err != nil {
-		return "", fmt.Errorf("could not convert domain `%s` to ASCII: %w", d.CustomerName, err)
-	}
-	return domainASCII, nil
-}
-
 // InfomaniakDNSRecord defines the format of a DNSRecord object
 type InfomaniakDNSRecord struct {
-	ID         string `json:"id,omitempty"`
-	Source     string `json:"source,omitempty"`
-	SourceIdn  string `json:"source_idn,omitempty"`
-	Type       string `json:"type,omitempty"`
-	TTL        uint64 `json:"ttl,omitempty"`
-	TTLIdn     string `json:"ttl_idn,omitempty"`
-	Target     string `json:"target,omitempty"`
-	TargetIdn  string `json:"target_idn,omitempty"`
-	UpdatedAt  uint64 `json:"updated_at,omitempty"`
-	DyndnsID   string `json:"dyndns_id,omitempty,omitempty"`
-	Priority   uint64 `json:"priority,omitempty"`
-	IsEditable bool   `json:"is_editable,omitempty"`
+	ID        uint64 `json:"id,omitempty"`
+	Source    string `json:"source,omitempty"`
+	SourceIdn string `json:"source_idn,omitempty"`
+	Type      string `json:"type,omitempty"`
+	TTL       uint64 `json:"ttl,omitempty"`
+	Target    string `json:"target,omitempty"`
+	UpdatedAt uint64 `json:"updated_at,omitempty"`
 }
 
-// ErrDomainNotFound
-var ErrDomainNotFound = errors.New("domain not found")
+// getRecordID gather a record id from its specs (zone, source, target, rtype)
+func (ik *InfomaniakAPI) getRecordID(zone, source, target, rtype string) (*uint64, error) {
+	klog.V(4).Infof("Getting all records for zone=%s, then match source=%s target=%s rtype=%s", zone, source, target, rtype)
 
-// GetDomainByName gather a Domain object from its name
-func (ik *InfomaniakAPI) GetDomainByName(name string) (*InfomaniakDNSDomain, error) {
-	klog.V(4).Infof("Getting domain matching `%s`", name)
-
-	// remove trailing . if present
-	if strings.HasSuffix(name, ".") {
-		name = name[:len(name)-1]
-	}
-
-	// Try to find the most specific domain
-	// starts with the FQDN, then remove each left label until we have a match
-	for {
-		i := strings.Index(name, ".")
-		if i == -1 {
-			break
-		}
-		params := url.Values{}
-		params.Add("service_name", "domain")
-		params.Add("customer_name", name)
-
-		resp, err := ik.get("/1/product", params)
-		if err != nil {
-			return nil, err
-		}
-
-		var domains []InfomaniakDNSDomain
-
-		if err = json.Unmarshal(*resp.Data, &domains); err != nil {
-			return nil, fmt.Errorf("expected array of Domain, got: %v", string(*resp.Data))
-		}
-
-		for _, domain := range domains {
-			domainASCII, err := domain.ASCIIName()
-			if err != nil {
-				return nil, err
-			}
-			if domainASCII == name {
-				klog.V(4).Infof("Domain `%s` found, id=`%d`", name, domain.ID)
-				return &domain, nil
-			}
-		}
-		klog.V(4).Infof("Domain `%s` not found, trying with `%s`", name, name[i+1:])
-		name = name[i+1:]
-	}
-
-	return nil, ErrDomainNotFound
-}
-
-// getRecordID gather a record id from its specs (domain, source, target, rtype)
-func (ik *InfomaniakAPI) getRecordID(domain *InfomaniakDNSDomain, source, target, rtype string) (*string, error) {
-	klog.V(4).Infof("Getting all record for domain=%d, then match source=%s target=%s rtype=%s", domain.ID, source, target, rtype)
-
-	resp, err := ik.get(fmt.Sprintf("/1/domain/%d/dns/record", domain.ID), nil)
+	resp, err := ik.get(fmt.Sprintf("/2/zones/%s/records", url.PathEscape(zone)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -281,12 +194,8 @@ func (ik *InfomaniakAPI) getRecordID(domain *InfomaniakDNSDomain, source, target
 		return nil, fmt.Errorf("expected array of Record, got: %v", string(*resp.Data))
 	}
 
-	if len(records) < 1 {
-		return nil, fmt.Errorf("no records in zone")
-	}
-
 	for _, record := range records {
-		if record.Source == source && record.Target == target && record.Type == rtype {
+		if record.Source == source && record.Type == rtype && unquoteTarget(record.Target) == target {
 			return &record.ID, nil
 		}
 	}
@@ -294,17 +203,27 @@ func (ik *InfomaniakAPI) getRecordID(domain *InfomaniakDNSDomain, source, target
 	return nil, nil
 }
 
-// EnsureDNSRecord ensures a record is present with the correct key
-func (ik *InfomaniakAPI) EnsureDNSRecord(domain *InfomaniakDNSDomain, source, target, rtype string, ttl uint64) error {
-	klog.V(4).Infof("Ensure record domain=%d source=%s target=%s rtype=%s TTL=%d", domain.ID, source, target, rtype, ttl)
+// unquoteTarget unquotes a dns record target when it is written in the quoted
+// zone file format (TXT records are returned quoted by the API)
+func unquoteTarget(target string) string {
+	unquoted, err := strconv.Unquote(target)
+	if err != nil {
+		return target
+	}
+	return unquoted
+}
 
-	recordID, err := ik.getRecordID(domain, source, target, rtype)
+// EnsureDNSRecord ensures a record is present with the correct key
+func (ik *InfomaniakAPI) EnsureDNSRecord(zone, source, target, rtype string, ttl uint64) error {
+	klog.V(4).Infof("Ensure record zone=%s source=%s target=%s rtype=%s TTL=%d", zone, source, target, rtype, ttl)
+
+	recordID, err := ik.getRecordID(zone, source, target, rtype)
 	if err != nil {
 		return err
 	}
 
 	if recordID != nil {
-		klog.V(4).Infof("Record already exists (domain=%d record=%s source=%s rtype=%s target=%s), skipping addition", domain.ID, *recordID, source, rtype, target)
+		klog.V(4).Infof("Record already exists (zone=%s record=%d source=%s rtype=%s target=%s), skipping addition", zone, *recordID, source, rtype, target)
 		return nil
 	}
 
@@ -314,26 +233,26 @@ func (ik *InfomaniakAPI) EnsureDNSRecord(domain *InfomaniakDNSDomain, source, ta
 		return err
 	}
 
-	klog.V(4).Infof("Adding record domain=%d (source=%s rtype=%s target=%s ttl=%d)", domain.ID, source, rtype, target, ttl)
-	_, err = ik.post(fmt.Sprintf("/1/domain/%d/dns/record", domain.ID), bytes.NewBuffer(rawJSON))
+	klog.V(4).Infof("Adding record zone=%s (source=%s rtype=%s target=%s ttl=%d)", zone, source, rtype, target, ttl)
+	_, err = ik.post(fmt.Sprintf("/2/zones/%s/records", url.PathEscape(zone)), bytes.NewBuffer(rawJSON))
 	return err
 }
 
 // RemoveDNSRecord ensures a record is absent
-func (ik *InfomaniakAPI) RemoveDNSRecord(domain *InfomaniakDNSDomain, source, target, rtype string) error {
-	klog.V(4).Infof("Remove record domain=%d source=%s rtype=%s target=%s", domain.ID, source, rtype, target)
-	recordID, err := ik.getRecordID(domain, source, target, rtype)
+func (ik *InfomaniakAPI) RemoveDNSRecord(zone, source, target, rtype string) error {
+	klog.V(4).Infof("Remove record zone=%s source=%s rtype=%s target=%s", zone, source, rtype, target)
+	recordID, err := ik.getRecordID(zone, source, target, rtype)
 	if err != nil {
 		return err
 	}
 
 	// the record is already absent doing nothing
-	if recordID == nil || len(*recordID) < 1 {
-		klog.V(4).Infof("No record found (domain=%d source=%s rtype=%s target=%s), skipping deletion", domain.ID, source, rtype, target)
+	if recordID == nil {
+		klog.V(4).Infof("No record found (zone=%s source=%s rtype=%s target=%s), skipping deletion", zone, source, rtype, target)
 		return nil
 	}
 
-	klog.V(4).Infof("Deleting record domain=%d record=%s (source=%s rtype=%s target=%s)", domain.ID, *recordID, source, rtype, target)
-	_, err = ik.delete(fmt.Sprintf("/1/domain/%d/dns/record/%s", domain.ID, *recordID))
+	klog.V(4).Infof("Deleting record zone=%s record=%d (source=%s rtype=%s target=%s)", zone, *recordID, source, rtype, target)
+	_, err = ik.delete(fmt.Sprintf("/2/zones/%s/records/%d", url.PathEscape(zone), *recordID))
 	return err
 }

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -260,3 +260,17 @@ func (ik *InfomaniakAPI) RemoveDNSRecord(zone, source, target, rtype string) err
 	_, err = ik.delete(fmt.Sprintf("/2/zones/%s/records/%d", url.PathEscape(zone), *recordID))
 	return err
 }
+
+// UpdateDNSRecord updates the target and the TTL of an existing record
+func (ik *InfomaniakAPI) UpdateDNSRecord(zone string, recordID uint64, target string, ttl uint64) error {
+	klog.V(4).Infof("Update record zone=%s record=%d target=%s ttl=%d", zone, recordID, target, ttl)
+
+	record := InfomaniakDNSRecord{Target: target, TTL: ttl}
+	rawJSON, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+
+	_, err = ik.put(fmt.Sprintf("/2/zones/%s/records/%d", url.PathEscape(zone), recordID), bytes.NewBuffer(rawJSON))
+	return err
+}

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -23,6 +23,7 @@ const (
 // It implements only the methods required for the ACME Challenge
 type InfomaniakAPI struct {
 	apiToken string
+	baseURL  string
 }
 
 // ErrorResponse defines the error response format, as described here https://api.infomaniak.com/doc#home
@@ -44,7 +45,60 @@ type InfomaniakAPIResponse struct {
 func NewInfomaniakAPI(apiToken string) *InfomaniakAPI {
 	return &InfomaniakAPI{
 		apiToken: apiToken,
+		baseURL:  infomaniakBaseURL,
 	}
+}
+
+// ErrZoneNotFound
+var ErrZoneNotFound = errors.New("zone not found")
+
+// GetZoneByName returns the name of the zone matching the given name,
+// walking up the domain labels until a zone is found
+func (ik *InfomaniakAPI) GetZoneByName(name string) (string, error) {
+	klog.V(4).Infof("Getting zone matching `%s`", name)
+
+	// remove trailing . if present
+	if strings.HasSuffix(name, ".") {
+		name = name[:len(name)-1]
+	}
+
+	// Try to find the most specific zone
+	// starts with the FQDN, then remove each left label until we have a match
+	for {
+		i := strings.Index(name, ".")
+		if i == -1 {
+			break
+		}
+
+		exists, err := ik.zoneExists(name)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			klog.V(4).Infof("Zone `%s` found", name)
+			return name, nil
+		}
+
+		klog.V(4).Infof("Zone `%s` not found, trying with `%s`", name, name[i+1:])
+		name = name[i+1:]
+	}
+
+	return "", ErrZoneNotFound
+}
+
+// zoneExists checks if a zone exists in the account
+func (ik *InfomaniakAPI) zoneExists(zone string) (bool, error) {
+	resp, err := ik.get(fmt.Sprintf("/2/zones/%s/exists", url.PathEscape(zone)), nil)
+	if err != nil {
+		return false, err
+	}
+
+	var exists bool
+	if err := json.Unmarshal(*resp.Data, &exists); err != nil {
+		return false, fmt.Errorf("expected boolean, got: %v", string(*resp.Data))
+	}
+
+	return exists, nil
 }
 
 // request builds the raw request
@@ -52,18 +106,18 @@ func (ik *InfomaniakAPI) request(method, path string, body io.Reader) (*Infomani
 	if path[0] != '/' {
 		path = "/" + path
 	}
-	url := infomaniakBaseURL + path
+	requestURL := ik.baseURL + path
 
 	client := &http.Client{}
 
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequest(method, requestURL, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+ik.apiToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	klog.V(6).Infof("%s %s", method, url)
+	klog.V(6).Infof("%s %s", method, requestURL)
 	rawResp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -93,6 +93,10 @@ func (ik *InfomaniakAPI) zoneExists(zone string) (bool, error) {
 		return false, err
 	}
 
+	if resp.Data == nil {
+		return false, fmt.Errorf("no data in response")
+	}
+
 	var exists bool
 	if err := json.Unmarshal(*resp.Data, &exists); err != nil {
 		return false, fmt.Errorf("expected boolean, got: %v", string(*resp.Data))

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -27,10 +27,28 @@ type InfomaniakAPI struct {
 
 // ErrorResponse defines the error response format, as described here https://api.infomaniak.com/doc#home
 type ErrorResponse struct {
-	Code        string            `json:"code"`
-	Description string            `json:"description,omitempty"`
-	Context     map[string]string `json:"context,omitempty"`
-	Errors      []ErrorResponse   `json:"errors,omitempty"`
+	Code        string          `json:"code"`
+	Description string          `json:"description,omitempty"`
+	Context     map[string]any  `json:"context,omitempty"`
+	Errors      []ErrorResponse `json:"errors,omitempty"`
+}
+
+// APIError represents an error returned by the Infomaniak API
+type APIError struct {
+	Code        string
+	Description string
+	Context     map[string]any
+}
+
+func (e *APIError) Error() string {
+	msg := e.Code
+	if e.Description != "" {
+		msg += ": " + e.Description
+	}
+	if len(e.Context) > 0 {
+		msg += fmt.Sprintf(" (context: %v)", e.Context)
+	}
+	return msg
 }
 
 // InfomaniakAPIResponse defines the generic response format, as described here https://api.infomaniak.com/doc#home
@@ -89,6 +107,11 @@ func (ik *InfomaniakAPI) GetZoneByName(name string) (string, error) {
 func (ik *InfomaniakAPI) zoneExists(zone string) (bool, error) {
 	resp, err := ik.get(fmt.Sprintf("/2/zones/%s/exists", url.PathEscape(zone)), nil)
 	if err != nil {
+		// a missing zone is reported as a 404 object_not_found error envelope
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.Code == "object_not_found" {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -136,7 +159,11 @@ func (ik *InfomaniakAPI) request(method, path string, body io.Reader) (*Infomani
 	klog.V(8).Infof("Response status: `%s` json response: `%v`", rawResp.Status, string(rawJSON))
 
 	if resp.Result != "success" {
-		return nil, fmt.Errorf("%s %s failed: %v", method, path, resp.ErrResponse)
+		return nil, fmt.Errorf("%s %s failed: %w", method, path, &APIError{
+			Code:        resp.ErrResponse.Code,
+			Description: resp.ErrResponse.Description,
+			Context:     resp.ErrResponse.Context,
+		})
 	}
 
 	return &resp, nil

--- a/infomaniak_api.go
+++ b/infomaniak_api.go
@@ -188,6 +188,10 @@ func (ik *InfomaniakAPI) getRecordID(zone, source, target, rtype string) (*uint6
 		return nil, err
 	}
 
+	if resp.Data == nil {
+		return nil, fmt.Errorf("no data in response")
+	}
+
 	var records []InfomaniakDNSRecord
 
 	if err = json.Unmarshal(*resp.Data, &records); err != nil {

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -93,5 +95,140 @@ func TestZoneExistsMissingData(t *testing.T) {
 
 	if _, err := ik.zoneExists("example.com"); err == nil {
 		t.Error("expected an error when the response has no data")
+	}
+}
+
+func TestGetRecordIDMatchesUnquotedTXTTarget(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		fmt.Fprint(w, `{"result":"success","data":[{"id":12,"source":"_acme-challenge","type":"TXT","target":"\"challenge-value\"","ttl":300}]}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	recordID, err := ik.getRecordID("example.com", "_acme-challenge", "challenge-value", "TXT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recordID == nil || *recordID != 12 {
+		t.Errorf("expected record id 12, got: %v", recordID)
+	}
+}
+
+func TestGetRecordIDNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":[]}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	recordID, err := ik.getRecordID("example.com", "_acme-challenge", "challenge-value", "TXT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recordID != nil {
+		t.Errorf("expected nil record id, got: %d", *recordID)
+	}
+}
+
+func TestEnsureDNSRecordCreatesWhenMissing(t *testing.T) {
+	var createdBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"result":"success","data":[]}`)
+		case http.MethodPost:
+			createdBody, _ = io.ReadAll(r.Body)
+			fmt.Fprint(w, `{"result":"success","data":{"id":42,"source":"_acme-challenge","type":"TXT","target":"challenge-value","ttl":300}}`)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	ik := newTestClient(t, mux)
+
+	if err := ik.EnsureDNSRecord("example.com", "_acme-challenge", "challenge-value", "TXT", 300); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var sent InfomaniakDNSRecord
+	if err := json.Unmarshal(createdBody, &sent); err != nil {
+		t.Fatalf("invalid JSON body: %v (%s)", err, createdBody)
+	}
+	if sent.Source != "_acme-challenge" || sent.Target != "challenge-value" || sent.Type != "TXT" || sent.TTL != 300 {
+		t.Errorf("unexpected record sent: %+v", sent)
+	}
+}
+
+func TestEnsureDNSRecordSkipsWhenExists(t *testing.T) {
+	created := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"result":"success","data":[{"id":12,"source":"_acme-challenge","type":"TXT","target":"\"challenge-value\"","ttl":300}]}`)
+		case http.MethodPost:
+			created = true
+			fmt.Fprint(w, `{"result":"success","data":{}}`)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	ik := newTestClient(t, mux)
+
+	if err := ik.EnsureDNSRecord("example.com", "_acme-challenge", "challenge-value", "TXT", 300); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Error("expected no POST when the record already exists")
+	}
+}
+
+func TestRemoveDNSRecordDeletesByID(t *testing.T) {
+	deleted := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":[{"id":12,"source":"_acme-challenge","type":"TXT","target":"\"challenge-value\"","ttl":300}]}`)
+	})
+	mux.HandleFunc("/2/zones/example.com/records/12", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		deleted = true
+		fmt.Fprint(w, `{"result":"success","data":true}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if err := ik.RemoveDNSRecord("example.com", "_acme-challenge", "challenge-value", "TXT"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleted {
+		t.Error("expected DELETE /2/zones/example.com/records/12 to be called")
+	}
+}
+
+func TestRemoveDNSRecordSkipsWhenAbsent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":[]}`)
+	})
+	mux.HandleFunc("/2/zones/example.com/records/", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("unexpected DELETE call")
+		fmt.Fprint(w, `{"result":"success","data":true}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if err := ik.RemoveDNSRecord("example.com", "_acme-challenge", "challenge-value", "TXT"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient returns an InfomaniakAPI client pointing at a test server
+func newTestClient(t *testing.T, handler http.Handler) *InfomaniakAPI {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &InfomaniakAPI{apiToken: "test-token", baseURL: srv.URL}
+}
+
+func TestGetZoneByNameDirectMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("unexpected Authorization header: %q", got)
+		}
+		fmt.Fprint(w, `{"result":"success","data":true}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	zone, err := ik.GetZoneByName("example.com.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if zone != "example.com" {
+		t.Errorf("expected zone `example.com`, got `%s`", zone)
+	}
+}
+
+func TestGetZoneByNameWalkUp(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/api.example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":false}`)
+	})
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":true}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	zone, err := ik.GetZoneByName("api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if zone != "example.com" {
+		t.Errorf("expected zone `example.com`, got `%s`", zone)
+	}
+}
+
+func TestGetZoneByNameNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":false}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if _, err := ik.GetZoneByName("api.example.com"); !errors.Is(err, ErrZoneNotFound) {
+		t.Errorf("expected ErrZoneNotFound, got: %v", err)
+	}
+}
+
+func TestRequestErrorEnvelope(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"result":"error","error":{"code":"not_authorized","description":"bad token"}}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if _, err := ik.zoneExists("example.com"); err == nil {
+		t.Error("expected an error when the API returns an error envelope")
+	}
+}

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -245,3 +245,30 @@ func TestRemoveDNSRecordSkipsWhenAbsent(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestUpdateDNSRecordSendsTargetAndTTL(t *testing.T) {
+	var updatedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records/12", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		updatedBody, _ = io.ReadAll(r.Body)
+		fmt.Fprint(w, `{"result":"success","data":{"id":12,"source":"_acme-challenge","type":"TXT","target":"new-value","ttl":600}}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if err := ik.UpdateDNSRecord("example.com", 12, "new-value", 600); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var sent InfomaniakDNSRecord
+	if err := json.Unmarshal(updatedBody, &sent); err != nil {
+		t.Fatalf("invalid JSON body: %v (%s)", err, updatedBody)
+	}
+	if sent.Target != "new-value" || sent.TTL != 600 {
+		t.Errorf("unexpected record sent: %+v", sent)
+	}
+}

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -82,3 +82,16 @@ func TestRequestErrorEnvelope(t *testing.T) {
 		t.Error("expected an error when the API returns an error envelope")
 	}
 }
+
+func TestZoneExistsMissingData(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success"}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if _, err := ik.zoneExists("example.com"); err == nil {
+		t.Error("expected an error when the response has no data")
+	}
+}

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -136,6 +136,19 @@ func TestGetRecordIDNotFound(t *testing.T) {
 	}
 }
 
+func TestGetRecordIDMissingData(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success"}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	if _, err := ik.getRecordID("example.com", "_acme-challenge", "challenge-value", "TXT"); err == nil {
+		t.Error("expected an error when the response has no data")
+	}
+}
+
 func TestEnsureDNSRecordCreatesWhenMissing(t *testing.T) {
 	var createdBody []byte
 	mux := http.NewServeMux()

--- a/infomaniak_api_test.go
+++ b/infomaniak_api_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -85,6 +86,27 @@ func TestRequestErrorEnvelope(t *testing.T) {
 	}
 }
 
+func TestRequestErrorEnvelopeWithArrayContext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"result":"error","error":{"code":"not_authorized","description":"Permission not granted","context":{"required_scopes":["dns:read"]}}}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	_, err := ik.zoneExists("example.com")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "response parsing error") {
+		t.Errorf("error envelope must be decoded, got a parsing error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not_authorized") {
+		t.Errorf("expected the API error code in the message, got: %v", err)
+	}
+}
+
 func TestZoneExistsMissingData(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
@@ -95,6 +117,45 @@ func TestZoneExistsMissingData(t *testing.T) {
 
 	if _, err := ik.zoneExists("example.com"); err == nil {
 		t.Error("expected an error when the response has no data")
+	}
+}
+
+func TestZoneExistsObjectNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"result":"error","error":{"code":"object_not_found","description":"Zone not found"}}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	exists, err := ik.zoneExists("example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected the zone to not exist on object_not_found")
+	}
+}
+
+func TestGetZoneByNameWalkUpObjectNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/2/zones/api.example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"result":"error","error":{"code":"object_not_found","description":"Zone not found"}}`)
+	})
+	mux.HandleFunc("/2/zones/example.com/exists", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"result":"success","data":true}`)
+	})
+
+	ik := newTestClient(t, mux)
+
+	zone, err := ik.GetZoneByName("api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if zone != "example.com" {
+		t.Errorf("expected zone `example.com`, got `%s`", zone)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -160,25 +160,21 @@ func (c *infomaniakDNSProviderSolver) do(ch *v1alpha1.ChallengeRequest, action a
 	}
 
 	ikAPI := NewInfomaniakAPI(apiToken)
-	domain, err := ikAPI.GetDomainByName(zone)
+	zone, err = ikAPI.GetZoneByName(zone)
 	if err != nil {
 		return err
 	}
 
-	domainASCII, err := domain.ASCIIName()
-	if err != nil {
-		return err
-	}
-	if strings.HasSuffix(source, domainASCII) {
-		source = strings.TrimSuffix(source, domainASCII)
+	if strings.HasSuffix(source, zone) {
+		source = strings.TrimSuffix(source, zone)
 		source = strings.TrimSuffix(source, ".")
 	}
 
 	switch action {
 	case actionPresent:
-		return ikAPI.EnsureDNSRecord(domain, source, target, "TXT", ttl)
+		return ikAPI.EnsureDNSRecord(zone, source, target, "TXT", ttl)
 	case actionCleanup:
-		return ikAPI.RemoveDNSRecord(domain, source, target, "TXT")
+		return ikAPI.RemoveDNSRecord(zone, source, target, "TXT")
 	}
 
 	return nil


### PR DESCRIPTION
### ℹ️ Context

The webhook still uses Infomaniak API v1, which is domain-ID based (`/1/product`, `/1/domain/{id}/dns/record`). Infomaniak now exposes a v2 zone-based DNS API (`/2/zones/{zone}/...`) that only requires the `dns:read` and `dns:write` scopes (instead of the `Domain` scope).

🔗 **Resources:**

- https://developer.infomaniak.com/docs/api/get/2/zones/%7Bzone%7D/records

### 🏗️ Solution

- Zone resolution via `GET /2/zones/{zone}/exists` with label walk-up until the first existing zone (v1 behavior preserved), otherwise `ErrZoneNotFound`
- Record CRUD via `GET`/`POST`/`PUT`/`DELETE /2/zones/{zone}/records[/{id}]` (integer `uint64` IDs, zone names path-escaped)
- Handling of TXT targets returned quoted by v2 (`strconv.Unquote` before comparison, raw fallback)
- Guard against a success response without `data` (prevents a panic)
- `main.go` rewired to the zone-name based API; v1 code (`GetDomainByName`, `InfomaniakDNSDomain`, etc.) removed
- `UpdateDNSRecord` (PUT) completes the CRUD surface (not used by the solver)
- README: required token scopes are now `dns:read` and `dns:write`
- New unit test suite over an `httptest` server (13 tests: label walk-up, skip-if-exists, unquoting, error envelopes) + credential-free `make unit-test` target
- HTTP response body is now closed in `request()`

**BREAKING CHANGE:** API tokens now require the `dns:read` and `dns:write` scopes instead of the `Domain` scope.

⚠️ Before release: run the live conformance suite (`TEST_ZONE_NAME=example.com. INFOMANIAK_TOKEN=... make test`), including the subdomain case.
